### PR TITLE
Add majority of TrustedSec public Remote-Ops BOF's

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -54,6 +54,71 @@ jobs:
         run: |
           chmod +x ./make_bof.sh
           ./make_bof.sh enableuser
+      
+      - name: ProcessDestroy
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh ProcessDestroy
+
+      - name: ProcessListHandles
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh ProcessListHandles
+
+      - name: reg_delete
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh reg_delete
+
+      - name: reg_save
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh reg_save
+
+      - name: sc_config
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh sc_config
+
+      - name: sc_create
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh sc_create
+
+      - name: sc_delete
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh sc_delete
+
+      - name: sc_description
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh sc_description
+
+      - name: sc_start
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh sc_start
+
+      - name: sc_stop
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh sc_stop
+
+      - name: schtasksdelete
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh schtasksdelete
+
+      - name: schtasksstop
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh schtasksstop
+
+      - name: setuserpass
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof.sh setuserpass
 
       - name: "Publish Release"
         uses: "marvinpinto/action-automatic-releases@latest"

--- a/src/Remote/ProcessDestroy/Makefile
+++ b/src/Remote/ProcessDestroy/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/ProcessDestroy/extension.json
+++ b/src/Remote/ProcessDestroy/extension.json
@@ -1,0 +1,37 @@
+{
+"name": "processdestroy",
+"version": "0.0.0",
+"command_name": "remote-process-destroy",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "N/A",
+"help": "Attempt to crash a local process by cutting all handles in it.",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "ProcessDestroy.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "ProcessDestroy.x86.o"
+}
+],
+"arguments": [
+    {
+    "name": "pid",
+    "desc": "Process id to manipulate",
+    "type": "integer",
+    "optional": false
+    },
+    {
+    "name": "handleNumber",
+    "desc": "Handle ID you want to cut, cut all if not provided",
+    "type": "integer",
+    "optional": true
+    }
+]
+}

--- a/src/Remote/ProcessListHandles/Makefile
+++ b/src/Remote/ProcessListHandles/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/ProcessListHandles/extension.json
+++ b/src/Remote/ProcessListHandles/extension.json
@@ -1,0 +1,31 @@
+{
+"name": "ProcessListHandles",
+"version": "0.0.0",
+"command_name": "remote-process-list-handles",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "N/A",
+"help": "list the various handles a process has open",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "ProcessListHandles.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "ProcessListHandles.x86.o"
+}
+],
+"arguments": [
+    {
+    "name": "pid",
+    "desc": "pid to list handles of",
+    "type": "int",
+    "optional": false
+    }
+]
+}

--- a/src/Remote/adcs_request/Makefile
+++ b/src/Remote/adcs_request/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe

--- a/src/Remote/adcs_request/extension.json
+++ b/src/Remote/adcs_request/extension.json
@@ -1,0 +1,61 @@
+{
+"name": "adcs_request",
+"version": "0.0.0",
+"command_name": "remote-adcs-request",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "N/A",
+"help": "Request an certificate from an AD certificate server",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "adcs_request.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "adcs_request.x86.o"
+}
+],
+"arguments": [
+    {
+    "name": "CA",
+    "desc": "certificate authority to make request against. format: <domain>\\<CA Name>",
+    "type": "wstring",
+    "optional": false
+    },
+    {
+    "name": "template",
+    "desc": "Template to request from CA",
+    "type": "wstring",
+    "optional": true
+    },
+    {
+    "name": "subject",
+    "desc": "Subject to use in request",
+    "type": "wstring",
+    "optional": true
+    },
+    {
+    "name": "alt-name",
+    "desc": "Alternative name to request on cert",
+    "type": "wstring",
+    "optional": true
+    },
+    {
+    "name": "Install",
+    "desc": "set to something other then zero to install cert under user account",
+    "type": "short",
+    "optional": true
+    },
+    {
+    "name": "Machine",
+    "desc": "if this is set along with install cert is installed under machine account instead of user",
+    "type": "short",
+    "optional": true
+    }
+]
+}

--- a/src/Remote/chromeKey/Makefile
+++ b/src/Remote/chromeKey/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c -g $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe

--- a/src/Remote/chromeKey/extension.json
+++ b/src/Remote/chromeKey/extension.json
@@ -1,0 +1,24 @@
+{
+"name": "chromeKey",
+"version": "0.0.0",
+"command_name": "remote-chrome-key",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "N/A",
+"help": "Get Decryption key usable with Chlonium (https://github.com/rxwx/chlonium)",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "chromeKey.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "chromeKey.x86.o"
+}
+],
+"arguments": []
+}

--- a/src/Remote/enableuser/Makefile
+++ b/src/Remote/enableuser/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)	
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/enableuser/extension.json
+++ b/src/Remote/enableuser/extension.json
@@ -1,0 +1,37 @@
+{
+"name": "enableuser",
+"version": "0.0.0",
+"command_name": "remote-enable-user",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "N/A",
+"help": "Unlock and enable a local / remote user account",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "enableuser.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "enableuser.x86.o"
+}
+],
+"arguments": [
+    {
+        "name": "ComputerName",
+        "desc": "Computer to enable / unlock account on.  Target DC for domain accounts. Use \"\" for  local computer",
+        "type": "wstring",
+        "optional": false
+    },
+    {
+        "name": "Username",
+        "desc": "Username to unlock / enable",
+        "type": "wstring",
+        "optional": false
+    }
+]
+}

--- a/src/Remote/reg_delete/Makefile
+++ b/src/Remote/reg_delete/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/reg_delete/extension.json
+++ b/src/Remote/reg_delete/extension.json
@@ -1,0 +1,55 @@
+{
+"name": "reg_delete",
+"version": "0.0.0",
+"command_name": "remote-reg-delete",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+"help": "Delete a registry key or value",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "reg_delete.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "reg_delete.x86.o"
+}
+],
+"arguments": [
+    {
+    "name": "hostname",
+    "desc": "\"\"=local else remote hostname",
+    "type": "string",
+    "optional": false
+    },
+    {
+    "name": "hive",
+    "desc": "0=HKCR|1=HKCU|2=HKLM|3=HKU",
+    "type": "int",
+    "optional": false
+    },
+    {
+    "name": "path",
+    "desc": "registry key path",
+    "type": "string",
+    "optional": false
+    },
+    {
+    "name": "value",
+    "desc": "value under key to delete, use \"\" when deleteing a whole key",
+    "type": "string",
+    "optional": false
+    },
+    {
+    "name": "Deletekey",
+    "desc": "Set to 1 when deleting a whole key",
+    "type": "int",
+    "optional": true
+    }
+]
+}

--- a/src/Remote/reg_save/Makefile
+++ b/src/Remote/reg_save/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/reg_save/extension.json
+++ b/src/Remote/reg_save/extension.json
@@ -1,0 +1,43 @@
+{
+"name": "reg_save",
+"version": "0.0.0",
+"command_name": "remote-reg-save",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+"help": "backup a registry have to a file on disk (requires Enabled SEBackup Priv)",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "reg_save.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "reg_save.x86.o"
+}
+],
+"arguments": [
+    {
+    "name": "path",
+    "desc": "parent key to initiate save from",
+    "type": "string",
+    "optional": false
+    },
+    {
+    "name": "output_path",
+    "desc": "path on target disk to write backup to",
+    "type": "string",
+    "optional": false
+    },
+    {
+    "name": "hive",
+    "desc": "0=HKCR|1=HKCU|2=HKLM|3=HKU",
+    "type": "int",
+    "optional": false
+    }
+]
+}

--- a/src/Remote/reg_set/Makefile
+++ b/src/Remote/reg_set/Makefile
@@ -10,6 +10,8 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	# cp extension.json ../../../Remote/$(BOFNAME)
+	#TODO: c file needs to be re-written to account for lack of server side coding support in sliver
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/sc_config/Makefile
+++ b/src/Remote/sc_config/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/sc_config/extension.json
+++ b/src/Remote/sc_config/extension.json
@@ -1,0 +1,56 @@
+{
+"name": "sc_config",
+"version": "0.0.0",
+"command_name": "remote-sc-config",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+"help": "configure an existing service",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "sc_config.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "sc_config.x86.o"
+}
+],
+"arguments": [
+    {
+    "name": "hostname",
+    "desc": "hostname to modify service on use \"\" for local system",
+    "type": "string",
+    "optional": false
+    },
+    {
+    "name": "service_name",
+    "desc": "name of service to configure",
+    "type": "string",
+    "optional": false
+    },
+    {
+    "name": "binpath",
+    "desc": "New binary path for service",
+    "type": "string",
+    "optional": false
+    },
+    {
+    "name": "error_mode",
+    "desc": "new error mode for service binary\n\t\t0=ignore|1=normal|2=severe|3=critical",
+    "type": "short",
+    "optional": false
+    },
+    {
+    "name": "start_mode",
+    "desc": "start mode for service\n\t\t2=auto|3=demand|4=disable",
+    "type": "short",
+    "optional": false
+    }
+
+]
+}

--- a/src/Remote/sc_create/Makefile
+++ b/src/Remote/sc_create/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/sc_create/extension.json
+++ b/src/Remote/sc_create/extension.json
@@ -1,0 +1,67 @@
+{
+"name": "sc_create",
+"version": "0.0.0",
+"command_name": "remote-sc-create",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+"help": "Create a new service on a windows system",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "sc_create.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "sc_create.x86.o"
+}
+],
+"arguments": [
+    {
+        "name": "hostname",
+        "desc": "hostname to create service on use \"\" for local system",
+        "type": "string",
+        "optional": false
+        },
+        {
+        "name": "service_name",
+        "desc": "name of service to create",
+        "type": "string",
+        "optional": false
+        },
+        {
+        "name": "binpath",
+        "desc": "New binary path for service",
+        "type": "string",
+        "optional": false
+        },
+        {
+        "name": "display_name",
+        "desc": "Service displayname to use",
+        "type": "string",
+        "optional": false
+        },
+        {
+        "name": "description",
+        "desc": "Service description to set",
+        "type": "string",
+        "optional": false
+        },
+        {
+        "name": "error_mode",
+        "desc": "new error mode for service binary\n\t\t0=ignore|1=normal|2=severe|3=critical",
+        "type": "short",
+        "optional": false
+        },
+        {
+        "name": "start_mode",
+        "desc": "start mode for service\n\t\t2=auto|3=demand|4=disable",
+        "type": "short",
+        "optional": false
+        }
+]
+}

--- a/src/Remote/sc_delete/Makefile
+++ b/src/Remote/sc_delete/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/sc_delete/extension.json
+++ b/src/Remote/sc_delete/extension.json
@@ -1,0 +1,37 @@
+{
+"name": "sc_delete",
+"version": "0.0.0",
+"command_name": "remote-sc-delete",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+"help": "delete a service from a windows based computer",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "sc_delete.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "sc_delete.x86.o"
+}
+],
+"arguments": [
+    {
+        "name": "hostname",
+        "desc": "hostname to delete service on from \"\" for local system",
+        "type": "string",
+        "optional": false
+        },
+        {
+        "name": "service_name",
+        "desc": "name of service to delete",
+        "type": "string",
+        "optional": false
+    }
+]
+}

--- a/src/Remote/sc_description/Makefile
+++ b/src/Remote/sc_description/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/sc_description/extension.json
+++ b/src/Remote/sc_description/extension.json
@@ -1,0 +1,43 @@
+{
+"name": "sc_description",
+"version": "0.0.0",
+"command_name": "remote-sc-description",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+"help": "change description of a server",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "sc_description.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "sc_description.x86.o"
+}
+],
+"arguments": [
+    {
+    "name": "hostname",
+    "desc": "hostname to modify service on use \"\" for local system",
+    "type": "string",
+    "optional": false
+    },
+    {
+    "name": "service_name",
+    "desc": "name of service to modify",
+    "type": "string",
+    "optional": false
+    },
+    {
+    "name": "description",
+    "desc": "Service description to set",
+    "type": "string",
+    "optional": false
+    }
+]
+}

--- a/src/Remote/sc_start/Makefile
+++ b/src/Remote/sc_start/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/sc_start/extension.json
+++ b/src/Remote/sc_start/extension.json
@@ -1,0 +1,37 @@
+{
+"name": "sc_start",
+"version": "0.0.0",
+"command_name": "remote-sc-start",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+"help": "Start service on a windows based system",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "sc_start.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "sc_start.x86.o"
+}
+],
+"arguments": [
+    {
+    "name": "hostname",
+    "desc": "hostname to start service on use \"\" for local system",
+    "type": "string",
+    "optional": false
+    },
+    {
+    "name": "service_name",
+    "desc": "name of service to start",
+    "type": "string",
+    "optional": false
+    }
+]
+}

--- a/src/Remote/sc_stop/Makefile
+++ b/src/Remote/sc_stop/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/sc_stop/extension.json
+++ b/src/Remote/sc_stop/extension.json
@@ -1,0 +1,37 @@
+{
+    "name": "sc_stop",
+    "version": "0.0.0",
+    "command_name": "remote-sc-stop",
+    "extension_author": "TrustedSec",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "stop service on a windows based system",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+    {
+    "os": "windows",
+    "arch": "amd64",
+    "path": "sc_stop.x64.o"
+    },
+    {
+    "os": "windows",
+    "arch": "386",
+    "path": "sc_stop.x86.o"
+    }
+    ],
+    "arguments": [
+        {
+        "name": "hostname",
+        "desc": "hostname to stop service on use \"\" for local system",
+        "type": "string",
+        "optional": false
+        },
+        {
+        "name": "service_name",
+        "desc": "name of service to stop",
+        "type": "string",
+        "optional": false
+        }
+    ]
+}

--- a/src/Remote/schtaskscreate/Makefile
+++ b/src/Remote/schtaskscreate/Makefile
@@ -10,6 +10,8 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
+	#need to modify C code to handle char to wchar file convesion
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/schtasksdelete/Makefile
+++ b/src/Remote/schtasksdelete/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/schtasksdelete/extension.json
+++ b/src/Remote/schtasksdelete/extension.json
@@ -1,0 +1,43 @@
+{
+"name": "schtasksdelete",
+"version": "0.0.0",
+"command_name": "remote-schtasks-delete",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+"help": "Delete a scheduled task",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "schtasksdelete.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "schtasksdelete.x86.o"
+}
+],
+"arguments": [
+    {
+    "name": "hostname",
+    "desc": "host to delete task from, use \"\" for local",
+    "type": "wstring",
+    "optional": false
+    },
+    {
+    "name": "task_path",
+    "desc": "path to task or folder to delete",
+    "type": "wstring",
+    "optional": false
+    },
+    {
+    "name": "isfolder",
+    "desc": "0=delete a task|1=delete a folder",
+    "type": "int",
+    "optional": true
+    }
+]
+}

--- a/src/Remote/schtasksstop/Makefile
+++ b/src/Remote/schtasksstop/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/schtasksstop/extension.json
+++ b/src/Remote/schtasksstop/extension.json
@@ -1,0 +1,37 @@
+{
+"name": "schtasksstop",
+"version": "0.0.0",
+"command_name": "remote-schtasks-stop",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+"help": "stop a running scheduled task",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "schtasksstop.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "schtasksstop.x86.o"
+}
+],
+"arguments": [
+    {
+        "name": "hostname",
+        "desc": "host to stop task on use \"\" for local",
+        "type": "wstring",
+        "optional": false
+        },
+        {
+        "name": "task_path",
+        "desc": "path to task to stop",
+        "type": "wstring",
+        "optional": false
+        }
+]
+}

--- a/src/Remote/setuserpass/Makefile
+++ b/src/Remote/setuserpass/Makefile
@@ -10,6 +10,7 @@ all:
 	$(CC_x86) -o $(BOFNAME).x86.o $(COMINCLUDE) -Os -c entry.c -DBOF
 	mkdir -p ../../../Remote/$(BOFNAME) 
 	mv $(BOFNAME)*.o ../../../Remote/$(BOFNAME)
+	cp extension.json ../../../Remote/$(BOFNAME)
 
 test:
 	$(CC_x64) entry.c $(COMINCLUDE) $(LIBINCLUDE) -o $(BOFNAME).x64.exe  

--- a/src/Remote/setuserpass/extension.json
+++ b/src/Remote/setuserpass/extension.json
@@ -1,0 +1,44 @@
+{
+"name": "setuserpass",
+"version": "0.0.0",
+"command_name": "remote-setuserpass",
+"extension_author": "TrustedSec",
+"original_author": "TrustedSec",
+"repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+"help": "set the password for a given user account",
+"depends_on": "coff-loader",
+"entrypoint": "go",
+"files": [
+{
+"os": "windows",
+"arch": "amd64",
+"path": "setuserpass.x64.o"
+},
+{
+"os": "windows",
+"arch": "386",
+"path": "setuserpass.x86.o"
+}
+],
+"arguments": [
+    {
+        "name": "domain",
+        "desc": "domain the account lives in, use \"\" for local system",
+        "type": "wstring",
+        "optional": false
+    },
+    {
+    "name": "username",
+    "desc": "Username to set account password on",
+    "type": "wstring",
+    "optional": false
+    },
+    {
+    "name": "password",
+    "desc": "password to set account to",
+    "type": "wstring",
+    "optional": false
+    },
+
+]
+}


### PR DESCRIPTION
This pull requests adds most of the remote ops bofs.  Some were excluded for the following reasons:

- procdump: supported by native agent already
- reg_set: unable to properly handle reg_multi_sz without modifying the C code
- schtaskscreate: unable to send xml file as a wchar_t, would need to modify C code
- shspawnas: native agent supports plenty of runas / inject already


Let me know what you think and if you want anything changed