### PR TITLE
Fix remote-sc-create

### DIFF
--- a/src/Remote/sc_create/extension.json
+++ b/src/Remote/sc_create/extension.json
@@ -65,9 +65,9 @@
         },
         {
         "name": "type",
-        "desc": "Optional. The type of service to create. The valid options are:\n\t\t1 - SERVICE_FILE_SYSTEM_DRIVER (File system driver service)\n\t\t2 - SERVICE_KERNEL_DRIVER (Driver service)\n\t\t3 - SERVICE_WIN32_OWN_PROCESS (Service that runs in its own process) <-- Default\n\t\t4 - SERVICE_WIN32_SHARE_PROCESS (Service that shares a process with one or more other services)",
+        "desc": "The type of service to create. The valid options are:\n\t\t1 - SERVICE_FILE_SYSTEM_DRIVER (File system driver service)\n\t\t2 - SERVICE_KERNEL_DRIVER (Driver service)\n\t\t16 - SERVICE_WIN32_OWN_PROCESS (Service that runs in its own process)\n\t\t32 - SERVICE_WIN32_SHARE_PROCESS (Service that shares a process with one or more other services)",
         "type": "short",
-        "optional": true
+        "optional": false
         }
 ]
 }

--- a/src/Remote/sc_create/extension.json
+++ b/src/Remote/sc_create/extension.json
@@ -62,6 +62,12 @@
         "desc": "start mode for service\n\t\t2=auto|3=demand|4=disable",
         "type": "short",
         "optional": false
+        },
+        {
+        "name": "type",
+        "desc": "Optional. The type of service to create. The valid options are:\n\t\t1 - SERVICE_FILE_SYSTEM_DRIVER (File system driver service)\n\t\t2 - SERVICE_KERNEL_DRIVER (Driver service)\n\t\t3 - SERVICE_WIN32_OWN_PROCESS (Service that runs in its own process) <-- Default\n\t\t4 - SERVICE_WIN32_SHARE_PROCESS (Service that shares a process with one or more other services)",
+        "type": "short",
+        "optional": true
         }
 ]
 }


### PR DESCRIPTION
It seems that TrustedSec added flexibility to choose the service type in the most recent commit to meet the popular demand for driver services. However, this was not updated in the Sliver Armory extension.json, breaking the command for a few months. This patch should fix it.

The normal service type is 0x10, which corresponds to 16 decimal. I am not sure if extensions allow you to set this as default. TrustedSec does this via the .cna script.

The command now works again when adding the service type at the end of the command:
remote-sc-create MACHINE bla 'C:\Users\User\Desktop\service-executable.exe' bla bla 0 2 16
![image](https://github.com/sliverarmory/CS-Remote-OPs-BOF/assets/74974697/b1a37aa8-62fa-45b9-9a28-030f887a065e)