### PR TITLE
Add injection extensions and incorporate in build

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -195,6 +195,66 @@ jobs:
           chmod +x ./make_bof.sh
           ./make_bof.sh slack_cookie
 
+      - name: clipboard
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh clipboard
+
+      - name: conhost
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh conhost
+
+      - name: createremotethread
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh createremotethread
+
+      - name: ctray
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh ctray
+
+      - name: dde
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh dde
+
+      - name: kernelcallbacktable
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh kernelcallbacktable
+
+      - name: ntcreatethread
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh ntcreatethread
+
+      - name: ntqueueapcthread
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh ntqueueapcthread
+
+      - name: setthreadcontext
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh setthreadcontext
+
+      - name: svcctrl
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh svcctrl
+
+      - name: tooltip
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh tooltip
+
+      - name: uxsubclassinfo
+        run: |
+          chmod +x ./make_bof.sh
+          ./make_bof_injection.sh uxsubclassinfo
+
       - name: "Publish Release"
         uses: "marvinpinto/action-automatic-releases@latest"
         with:

--- a/make_bof_injection.sh
+++ b/make_bof_injection.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# variables
+HOME=$(pwd)
+BOF=$1
+SRCDIR="$HOME/src/Injection/$BOF"
+OUTDIR="$HOME/Injection/$BOF"
+PKGS=$HOME/packages
+
+# compile
+echo "[+] Changing directory: $SRCDIR"
+cd $SRCDIR
+echo "[+] Compiling: $BOF"
+make
+
+# archive
+echo "[+] Creating artifact:"
+mkdir artifacts # $SRCDIR/artifacts/
+mv $OUTDIR/*.o ./artifacts/
+VERSION=$(git describe --tags --abbrev=0)
+cat extension.json | jq ".version |= \"$VERSION\"" > ./artifacts/extension.json
+cd artifacts # ./src/Injection/$BOF/artifacts/
+echo
+pwd
+ls -l
+echo
+
+# package
+mkdir -p $PKGS
+echo "[+] Creating package:"
+MANIFEST=$(cat extension.json | base64 -w 0)
+COMMAND_NAME=$(cat extension.json | jq -r .command_name)
+echo "[+] executing: tar -czvf $PKGS/$COMMAND_NAME.tar.gz ."
+tar -czvf $PKGS/$COMMAND_NAME.tar.gz .
+cd $PKGS
+echo
+pwd
+ls -l
+
+# sign
+echo "[+] Signing package:"
+bash -c "echo \"\" | /home/runner/minisign -s /home/runner/minisign.key -S -m ./$COMMAND_NAME.tar.gz -t \"$MANIFEST\" -x $COMMAND_NAME.minisig"

--- a/src/Injection/clipboard/extension.json
+++ b/src/Injection/clipboard/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "clipboard",
+    "version": "v0.0.7",
+    "command_name": "inject-clipboard",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "clipboard.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "clipboard.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  

--- a/src/Injection/conhost/extension.json
+++ b/src/Injection/conhost/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "conhost",
+    "version": "v0.0.7",
+    "command_name": "inject-conhost",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "conhost.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "conhost.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  

--- a/src/Injection/createremotethread/extension.json
+++ b/src/Injection/createremotethread/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "createremotethread",
+    "version": "v0.0.7",
+    "command_name": "inject-createremotethread",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "createremotethread.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "createremotethread.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  

--- a/src/Injection/ctray/extension.json
+++ b/src/Injection/ctray/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "ctray",
+    "version": "v0.0.7",
+    "command_name": "inject-ctray",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "ctray.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "ctray.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  

--- a/src/Injection/dde/extension.json
+++ b/src/Injection/dde/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "dde",
+    "version": "v0.0.7",
+    "command_name": "inject-dde",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "dde.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "dde.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  

--- a/src/Injection/kernelcallbacktable/extension.json
+++ b/src/Injection/kernelcallbacktable/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "kernelcallbacktable",
+    "version": "v0.0.7",
+    "command_name": "inject-kernelcallbacktable",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "kernelcallbacktable.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "kernelcallbacktable.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  

--- a/src/Injection/ntcreatethread/extension.json
+++ b/src/Injection/ntcreatethread/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "ntcreatethread",
+    "version": "v0.0.7",
+    "command_name": "inject-ntcreatethread",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "ntcreatethread.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "ntcreatethread.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  

--- a/src/Injection/ntqueueapcthread/extension.json
+++ b/src/Injection/ntqueueapcthread/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "ntqueueapcthread",
+    "version": "v0.0.7",
+    "command_name": "inject-ntqueueapcthread",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "ntqueueapcthread.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "ntqueueapcthread.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  

--- a/src/Injection/setthreadcontext/extension.json
+++ b/src/Injection/setthreadcontext/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "setthreadcontext",
+    "version": "v0.0.7",
+    "command_name": "inject-setthreadcontext",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "setthreadcontext.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "setthreadcontext.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  

--- a/src/Injection/svcctrl/extension.json
+++ b/src/Injection/svcctrl/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "svcctrl",
+    "version": "v0.0.7",
+    "command_name": "inject-svcctrl",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "svcctrl.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "svcctrl.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  

--- a/src/Injection/tooltip/extension.json
+++ b/src/Injection/tooltip/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "tooltip",
+    "version": "v0.0.7",
+    "command_name": "inject-tooltip",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "tooltip.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "tooltip.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  

--- a/src/Injection/uxsubclassinfo/extension.json
+++ b/src/Injection/uxsubclassinfo/extension.json
@@ -1,0 +1,38 @@
+{
+    "name": "uxsubclassinfo",
+    "version": "v0.0.7",
+    "command_name": "inject-uxsubclassinfo",
+    "extension_author": "0xbad53c",
+    "original_author": "TrustedSec",
+    "repo_url": "https://github.com/sliverarmory/CS-Remote-OPs-BOF",
+    "help": "inject into a process",
+    "depends_on": "coff-loader",
+    "entrypoint": "go",
+    "files": [
+      {
+        "os": "windows",
+        "arch": "amd64",
+        "path": "uxsubclassinfo.x64.o"
+      },
+      {
+        "os": "windows",
+        "arch": "386",
+        "path": "uxsubclassinfo.x86.o"
+      }
+    ],
+    "arguments": [
+  {
+        "name": "pid",
+        "desc": "process id",
+        "type": "int",
+        "optional": false
+      },
+      {
+        "name": "bin",
+        "desc": "/local/path/to/shellcode.bin",
+        "type": "file",
+        "optional": false
+      }
+    ]
+  }
+  


### PR DESCRIPTION
Hi folks,

I added extensions for TrustedSec's injection techniques to enabled other red/blue teamers to emulate these more easily. I noticed that many of these have been published and used since at least 2017, but it seems that some detective tooling did not pick up on them yet. It would be good input for a purple team exercise!

Credits obviously go to TrustedSec to release their implementation to the community and to the awesome authors of Sliver for their flexible, open-source C2 framework!

I tried to also commit the following to the GitHub autorelease file, but please review and test as I'm not familiar with GitHub CI.
```
  - name: clipboard
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh clipboard

  - name: conhost
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh conhost

  - name: createremotethread
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh createremotethread

  - name: ctray
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh ctray

  - name: dde
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh dde

  - name: kernelcallbacktable
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh kernelcallbacktable

  - name: ntcreatethread
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh ntcreatethread

  - name: ntqueueapcthread
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh ntqueueapcthread

  - name: setthreadcontext
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh setthreadcontext

  - name: svcctrl
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh svcctrl

  - name: tooltip
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh tooltip

  - name: uxsubclassinfo
    run: |
      chmod +x ./make_bof.sh
      ./make_bof_injection.sh uxsubclassinfo
```