### PR TITLE
Update extension.json

### DIFF
--- a/src/Remote/schtaskscreate/extension.json
+++ b/src/Remote/schtaskscreate/extension.json
@@ -33,16 +33,22 @@
         "type": "wstring",
         "optional": false
       },
+        {
+            "name": "xml",
+            "desc": "The contents of the XML file to write to disk",
+            "type": "wstring",
+            "optional": false,
+        },
       {
         "name": "usermode",
-        "desc": "username for the task <USER | XML | SYSTEM>",
-        "type": "wstring",
+        "desc": "0 for USER, 1 for SYSTEM, 2 for PRINCIPAL",
+        "type": "int",
         "optional": false
       },
       {
         "name": "forcemode",
-        "desc": "creation disposition <CREATE | UPDATE>",
-        "type": "wstring",
+        "desc": "Force boolean, 0 or 1",
+        "type": "int",
         "optional": false
       }
     ]


### PR DESCRIPTION
fixing extension.json to match the entry.c program here:
https://github.com/sliverarmory/CS-Remote-OPs-BOF/blob/main/src/Remote/schtaskscreate/entry.c#L540-L551
```
	const wchar_t * hostname = NULL;
	wchar_t * taskpath = NULL;
	const wchar_t * xml = NULL;
	int mode = 0;
	BOOL force = 0;

	BeaconDataParse(&parser, Buffer, Length);
	hostname = (const wchar_t *)BeaconDataExtract(&parser, NULL);
	taskpath = (wchar_t *)BeaconDataExtract(&parser, NULL);
	xml = (const wchar_t *)BeaconDataExtract(&parser, NULL);
	mode = BeaconDataInt(&parser);
	force = BeaconDataInt(&parser);
```